### PR TITLE
Updated markedjs to 0.3.19 to close vulnerability; updated to npm 6.0.0

### DIFF
--- a/bundles/ranvier-websocket/package-lock.json
+++ b/bundles/ranvier-websocket/package-lock.json
@@ -19,8 +19,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.1.0.tgz",
       "integrity": "sha512-TU4/qKFlyQFqNITNWiqPCUY9GqlAhEotlzfcZcve6VT1YEngQl1dDMqwQQS3eMYruJ5r/UD3lcsWib6iVMDGDw==",
       "requires": {
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.0"
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2089,7 +2089,7 @@
         "escape-string-regexp": "1.0.5",
         "js2xmlparser": "3.0.0",
         "klaw": "2.0.0",
-        "marked": "0.3.6",
+        "marked": "0.3.19",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "2.0.1",
@@ -2728,9 +2728,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
     "micromatch": {
@@ -2910,6 +2910,5117 @@
       "dev": true,
       "requires": {
         "remove-trailing-separator": "1.0.2"
+      }
+    },
+    "npm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.0.0.tgz",
+      "integrity": "sha512-EtM7gNAgMdQeUh8SW2bsaogywVS37lPhf2GYAf2vxR1pktxxT02CW8BHrx59MSbG3ZrRBbcOhpe03gts+eAbdA==",
+      "requires": {
+        "JSONStream": "1.3.2",
+        "abbrev": "1.1.1",
+        "ansi-regex": "3.0.0",
+        "ansicolors": "0.3.2",
+        "ansistyles": "0.1.3",
+        "aproba": "1.2.0",
+        "archy": "1.0.0",
+        "bin-links": "1.1.2",
+        "bluebird": "3.5.1",
+        "byte-size": "4.0.2",
+        "cacache": "11.0.1",
+        "call-limit": "1.1.0",
+        "chownr": "1.0.1",
+        "cli-columns": "3.1.2",
+        "cli-table2": "0.2.0",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.11",
+        "debuglog": "1.0.1",
+        "detect-indent": "5.0.0",
+        "detect-newline": "2.1.0",
+        "dezalgo": "1.0.3",
+        "editor": "1.0.0",
+        "figgy-pudding": "3.1.0",
+        "find-npm-prefix": "1.0.2",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "gentle-fs": "2.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "has-unicode": "2.0.1",
+        "hosted-git-info": "2.6.0",
+        "iferr": "1.0.0",
+        "imurmurhash": "0.1.4",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ini": "1.3.5",
+        "init-package-json": "1.10.3",
+        "is-cidr": "2.0.5",
+        "json-parse-better-errors": "1.0.2",
+        "lazy-property": "1.0.0",
+        "libcipm": "1.6.2",
+        "libnpmhook": "4.0.1",
+        "libnpx": "10.2.0",
+        "lockfile": "1.0.3",
+        "lodash._baseindexof": "3.1.0",
+        "lodash._baseuniq": "4.6.0",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2",
+        "lodash._getnative": "3.9.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.restparam": "3.6.1",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.without": "4.4.0",
+        "lru-cache": "4.1.2",
+        "meant": "1.0.1",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "node-gyp": "3.6.2",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.4.0",
+        "npm-audit-report": "1.0.5",
+        "npm-cache-filename": "1.0.2",
+        "npm-install-checks": "3.0.0",
+        "npm-lifecycle": "2.0.1",
+        "npm-package-arg": "6.1.0",
+        "npm-packlist": "1.1.10",
+        "npm-pick-manifest": "2.1.0",
+        "npm-profile": "3.0.1",
+        "npm-registry-client": "8.5.1",
+        "npm-registry-fetch": "1.1.0",
+        "npm-user-validate": "1.0.0",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "opener": "1.4.3",
+        "osenv": "0.1.5",
+        "pacote": "8.1.0",
+        "path-is-inside": "1.0.2",
+        "promise-inflight": "1.0.1",
+        "qrcode-terminal": "0.12.0",
+        "query-string": "6.0.0",
+        "qw": "1.0.1",
+        "read": "1.0.7",
+        "read-cmd-shim": "1.0.1",
+        "read-installed": "4.0.3",
+        "read-package-json": "2.0.13",
+        "read-package-tree": "5.2.1",
+        "readable-stream": "2.3.6",
+        "readdir-scoped-modules": "1.0.2",
+        "request": "2.85.0",
+        "retry": "0.12.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.1",
+        "semver": "5.5.0",
+        "sha": "2.0.1",
+        "slide": "1.1.6",
+        "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
+        "ssri": "6.0.0",
+        "strip-ansi": "4.0.0",
+        "tar": "4.4.1",
+        "text-table": "0.2.0",
+        "tiny-relative-date": "1.3.0",
+        "uid-number": "0.0.6",
+        "umask": "1.1.0",
+        "unique-filename": "1.1.0",
+        "unpipe": "1.0.0",
+        "update-notifier": "2.4.0",
+        "uuid": "3.2.1",
+        "validate-npm-package-license": "3.0.3",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.3.0",
+        "worker-farm": "1.6.0",
+        "wrappy": "1.0.2",
+        "write-file-atomic": "2.3.0"
+      },
+      "dependencies": {
+        "JSONStream": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            }
+          }
+        },
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "ansicolors": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "ansistyles": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "bin-links": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "cmd-shim": "2.0.2",
+            "gentle-fs": "2.0.1",
+            "graceful-fs": "4.1.11",
+            "write-file-atomic": "2.3.0"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "bundled": true
+        },
+        "byte-size": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "cacache": {
+          "version": "11.0.1",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "chownr": "1.0.1",
+            "figgy-pudding": "3.1.0",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lru-cache": "4.1.2",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.2",
+            "ssri": "6.0.0",
+            "unique-filename": "1.1.0",
+            "y18n": "4.0.0"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "call-limit": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "cli-columns": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+              },
+              "dependencies": {
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "3.0.0"
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "cli-table2": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "colors": "1.1.2",
+            "lodash": "3.10.1",
+            "string-width": "1.0.2"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              },
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "cmd-shim": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "columnify": {
+          "version": "1.5.4",
+          "bundled": true,
+          "requires": {
+            "strip-ansi": "3.0.1",
+            "wcwidth": "1.0.1"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                }
+              }
+            },
+            "wcwidth": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "defaults": "1.0.3"
+              },
+              "dependencies": {
+                "defaults": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "clone": "1.0.2"
+                  },
+                  "dependencies": {
+                    "clone": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "config-chain": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "ini": "1.3.5",
+            "proto-list": "1.2.4"
+          },
+          "dependencies": {
+            "proto-list": {
+              "version": "1.2.4",
+              "bundled": true
+            }
+          }
+        },
+        "debuglog": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "detect-indent": {
+          "version": "5.0.0",
+          "bundled": true
+        },
+        "detect-newline": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "dezalgo": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "asap": "2.0.5",
+            "wrappy": "1.0.2"
+          },
+          "dependencies": {
+            "asap": {
+              "version": "2.0.5",
+              "bundled": true
+            }
+          }
+        },
+        "editor": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "figgy-pudding": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "find-npm-prefix": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "fs-vacuum": {
+          "version": "1.2.10",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "path-is-inside": "1.0.2",
+            "rimraf": "2.6.2"
+          }
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.3.6"
+          },
+          "dependencies": {
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true
+            }
+          }
+        },
+        "gentle-fs": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "fs-vacuum": "1.2.10",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "path-is-inside": "1.0.2",
+            "read-cmd-shim": "1.0.1",
+            "slide": "1.1.6"
+          },
+          "dependencies": {
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          },
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.8",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "hosted-git-info": {
+          "version": "2.6.0",
+          "bundled": true
+        },
+        "iferr": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "init-package-json": {
+          "version": "1.10.3",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "npm-package-arg": "6.1.0",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.13",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3",
+            "validate-npm-package-name": "3.0.0"
+          },
+          "dependencies": {
+            "promzard": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "read": "1.0.7"
+              }
+            }
+          }
+        },
+        "is-cidr": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "cidr-regex": "2.0.8"
+          },
+          "dependencies": {
+            "cidr-regex": {
+              "version": "2.0.8",
+              "bundled": true,
+              "requires": {
+                "ip-regex": "2.1.0"
+              },
+              "dependencies": {
+                "ip-regex": {
+                  "version": "2.1.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "lazy-property": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "libcipm": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "bin-links": "1.1.2",
+            "bluebird": "3.5.1",
+            "find-npm-prefix": "1.0.2",
+            "graceful-fs": "4.1.11",
+            "lock-verify": "2.0.1",
+            "npm-lifecycle": "2.0.1",
+            "npm-logical-tree": "1.2.1",
+            "npm-package-arg": "6.1.0",
+            "pacote": "7.6.1",
+            "protoduck": "5.0.0",
+            "read-package-json": "2.0.13",
+            "rimraf": "2.6.2",
+            "worker-farm": "1.6.0"
+          },
+          "dependencies": {
+            "lock-verify": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "npm-package-arg": "5.1.2",
+                "semver": "5.5.0"
+              },
+              "dependencies": {
+                "npm-package-arg": {
+                  "version": "5.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "hosted-git-info": "2.6.0",
+                    "osenv": "0.1.5",
+                    "semver": "5.5.0",
+                    "validate-npm-package-name": "3.0.0"
+                  }
+                }
+              }
+            },
+            "npm-logical-tree": {
+              "version": "1.2.1",
+              "bundled": true
+            },
+            "pacote": {
+              "version": "7.6.1",
+              "bundled": true,
+              "requires": {
+                "bluebird": "3.5.1",
+                "cacache": "10.0.4",
+                "get-stream": "3.0.0",
+                "glob": "7.1.2",
+                "lru-cache": "4.1.2",
+                "make-fetch-happen": "2.6.0",
+                "minimatch": "3.0.4",
+                "mississippi": "3.0.0",
+                "mkdirp": "0.5.1",
+                "normalize-package-data": "2.4.0",
+                "npm-package-arg": "6.1.0",
+                "npm-packlist": "1.1.10",
+                "npm-pick-manifest": "2.1.0",
+                "osenv": "0.1.5",
+                "promise-inflight": "1.0.1",
+                "promise-retry": "1.1.1",
+                "protoduck": "5.0.0",
+                "rimraf": "2.6.2",
+                "safe-buffer": "5.1.1",
+                "semver": "5.5.0",
+                "ssri": "5.3.0",
+                "tar": "4.4.1",
+                "unique-filename": "1.1.0",
+                "which": "1.3.0"
+              },
+              "dependencies": {
+                "cacache": {
+                  "version": "10.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.2",
+                    "mississippi": "2.0.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "5.3.0",
+                    "unique-filename": "1.1.0",
+                    "y18n": "4.0.0"
+                  },
+                  "dependencies": {
+                    "mississippi": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "2.0.1",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
+                      },
+                      "dependencies": {
+                        "concat-stream": {
+                          "version": "1.6.2",
+                          "bundled": true,
+                          "requires": {
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
+                          },
+                          "dependencies": {
+                            "buffer-from": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "typedarray": {
+                              "version": "0.0.6",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexify": {
+                          "version": "3.5.4",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0"
+                          }
+                        },
+                        "flush-write-stream": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "from2": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "parallel-transform": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          },
+                          "dependencies": {
+                            "cyclist": {
+                              "version": "0.2.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        },
+                        "pumpify": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
+                          }
+                        },
+                        "stream-each": {
+                          "version": "1.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
+                          },
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "y18n": {
+                      "version": "4.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "get-stream": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "make-fetch-happen": {
+                  "version": "2.6.0",
+                  "bundled": true,
+                  "requires": {
+                    "agentkeepalive": "3.4.1",
+                    "cacache": "10.0.4",
+                    "http-cache-semantics": "3.8.1",
+                    "http-proxy-agent": "2.1.0",
+                    "https-proxy-agent": "2.2.1",
+                    "lru-cache": "4.1.2",
+                    "mississippi": "1.3.1",
+                    "node-fetch-npm": "2.0.2",
+                    "promise-retry": "1.1.1",
+                    "socks-proxy-agent": "3.0.1",
+                    "ssri": "5.3.0"
+                  },
+                  "dependencies": {
+                    "agentkeepalive": {
+                      "version": "3.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "humanize-ms": "1.2.1"
+                      },
+                      "dependencies": {
+                        "humanize-ms": {
+                          "version": "1.2.1",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.1.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "http-cache-semantics": {
+                      "version": "3.8.1",
+                      "bundled": true
+                    },
+                    "http-proxy-agent": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "3.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "https-proxy-agent": {
+                      "version": "2.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "3.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mississippi": {
+                      "version": "1.3.1",
+                      "bundled": true,
+                      "requires": {
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "1.0.3",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
+                      },
+                      "dependencies": {
+                        "concat-stream": {
+                          "version": "1.6.2",
+                          "bundled": true,
+                          "requires": {
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
+                          },
+                          "dependencies": {
+                            "buffer-from": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "typedarray": {
+                              "version": "0.0.6",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexify": {
+                          "version": "3.5.4",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0"
+                          }
+                        },
+                        "flush-write-stream": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "from2": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "parallel-transform": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          },
+                          "dependencies": {
+                            "cyclist": {
+                              "version": "0.2.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "pump": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        },
+                        "pumpify": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
+                          },
+                          "dependencies": {
+                            "pump": {
+                              "version": "2.0.1",
+                              "bundled": true,
+                              "requires": {
+                                "end-of-stream": "1.4.1",
+                                "once": "1.4.0"
+                              }
+                            }
+                          }
+                        },
+                        "stream-each": {
+                          "version": "1.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
+                          },
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "node-fetch-npm": {
+                      "version": "2.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "encoding": "0.1.12",
+                        "json-parse-better-errors": "1.0.2",
+                        "safe-buffer": "5.1.1"
+                      },
+                      "dependencies": {
+                        "encoding": {
+                          "version": "0.1.12",
+                          "bundled": true,
+                          "requires": {
+                            "iconv-lite": "0.4.21"
+                          },
+                          "dependencies": {
+                            "iconv-lite": {
+                              "version": "0.4.21",
+                              "bundled": true,
+                              "requires": {
+                                "safer-buffer": "2.1.2"
+                              },
+                              "dependencies": {
+                                "safer-buffer": {
+                                  "version": "2.1.2",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks-proxy-agent": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "socks": "1.1.10"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "socks": {
+                          "version": "1.1.10",
+                          "bundled": true,
+                          "requires": {
+                            "ip": "1.1.5",
+                            "smart-buffer": "1.1.15"
+                          },
+                          "dependencies": {
+                            "ip": {
+                              "version": "1.1.5",
+                              "bundled": true
+                            },
+                            "smart-buffer": {
+                              "version": "1.1.15",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.11"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.11",
+                      "bundled": true,
+                      "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "promise-retry": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
+                  },
+                  "dependencies": {
+                    "err-code": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    },
+                    "retry": {
+                      "version": "0.10.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "ssri": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.1"
+                  }
+                }
+              }
+            },
+            "protoduck": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "genfun": "4.0.1"
+              },
+              "dependencies": {
+                "genfun": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "libnpmhook": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "3.1.0",
+            "npm-registry-fetch": "3.1.1"
+          },
+          "dependencies": {
+            "npm-registry-fetch": {
+              "version": "3.1.1",
+              "bundled": true,
+              "requires": {
+                "bluebird": "3.5.1",
+                "figgy-pudding": "3.1.0",
+                "lru-cache": "4.1.2",
+                "make-fetch-happen": "4.0.1",
+                "npm-package-arg": "6.1.0"
+              },
+              "dependencies": {
+                "make-fetch-happen": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agentkeepalive": "3.4.1",
+                    "cacache": "11.0.1",
+                    "http-cache-semantics": "3.8.1",
+                    "http-proxy-agent": "2.1.0",
+                    "https-proxy-agent": "2.2.1",
+                    "lru-cache": "4.1.2",
+                    "mississippi": "3.0.0",
+                    "node-fetch-npm": "2.0.2",
+                    "promise-retry": "1.1.1",
+                    "socks-proxy-agent": "4.0.0",
+                    "ssri": "6.0.0"
+                  },
+                  "dependencies": {
+                    "agentkeepalive": {
+                      "version": "3.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "humanize-ms": "1.2.1"
+                      },
+                      "dependencies": {
+                        "humanize-ms": {
+                          "version": "1.2.1",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.1.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "http-cache-semantics": {
+                      "version": "3.8.1",
+                      "bundled": true
+                    },
+                    "http-proxy-agent": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "3.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "https-proxy-agent": {
+                      "version": "2.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "3.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "node-fetch-npm": {
+                      "version": "2.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "encoding": "0.1.12",
+                        "json-parse-better-errors": "1.0.2",
+                        "safe-buffer": "5.1.1"
+                      },
+                      "dependencies": {
+                        "encoding": {
+                          "version": "0.1.12",
+                          "bundled": true,
+                          "requires": {
+                            "iconv-lite": "0.4.21"
+                          },
+                          "dependencies": {
+                            "iconv-lite": {
+                              "version": "0.4.21",
+                              "bundled": true,
+                              "requires": {
+                                "safer-buffer": "2.1.2"
+                              },
+                              "dependencies": {
+                                "safer-buffer": {
+                                  "version": "2.1.2",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "promise-retry": {
+                      "version": "1.1.1",
+                      "bundled": true,
+                      "requires": {
+                        "err-code": "1.1.2",
+                        "retry": "0.10.1"
+                      },
+                      "dependencies": {
+                        "err-code": {
+                          "version": "1.1.2",
+                          "bundled": true
+                        },
+                        "retry": {
+                          "version": "0.10.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "socks-proxy-agent": {
+                      "version": "4.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.1.2",
+                        "socks": "2.1.6"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.1.2",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "socks": {
+                          "version": "2.1.6",
+                          "bundled": true,
+                          "requires": {
+                            "ip": "1.1.5",
+                            "smart-buffer": "4.0.1"
+                          },
+                          "dependencies": {
+                            "ip": {
+                              "version": "1.1.5",
+                              "bundled": true
+                            },
+                            "smart-buffer": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "libnpx": {
+          "version": "10.2.0",
+          "bundled": true,
+          "requires": {
+            "dotenv": "5.0.1",
+            "npm-package-arg": "6.1.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.1",
+            "update-notifier": "2.4.0",
+            "which": "1.3.0",
+            "y18n": "4.0.0",
+            "yargs": "11.0.0"
+          },
+          "dependencies": {
+            "dotenv": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "y18n": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "11.0.0",
+              "bundled": true,
+              "requires": {
+                "cliui": "4.0.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "9.0.2"
+              },
+              "dependencies": {
+                "cliui": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "2.1.1",
+                    "strip-ansi": "4.0.0",
+                    "wrap-ansi": "2.1.0"
+                  },
+                  "dependencies": {
+                    "wrap-ansi": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "string-width": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
+                          },
+                          "dependencies": {
+                            "code-point-at": {
+                              "version": "1.1.0",
+                              "bundled": true
+                            },
+                            "is-fullwidth-code-point": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "number-is-nan": "1.0.1"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "ansi-regex": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "bundled": true
+                },
+                "find-up": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "locate-path": "2.0.0"
+                  },
+                  "dependencies": {
+                    "locate-path": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
+                      },
+                      "dependencies": {
+                        "p-locate": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "p-limit": "1.2.0"
+                          },
+                          "dependencies": {
+                            "p-limit": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "p-try": "1.0.0"
+                              },
+                              "dependencies": {
+                                "p-try": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-exists": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "get-caller-file": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "os-locale": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "execa": "0.7.0",
+                    "lcid": "1.0.0",
+                    "mem": "1.1.0"
+                  },
+                  "dependencies": {
+                    "execa": {
+                      "version": "0.7.0",
+                      "bundled": true,
+                      "requires": {
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                      },
+                      "dependencies": {
+                        "cross-spawn": {
+                          "version": "5.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "lru-cache": "4.1.2",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
+                          },
+                          "dependencies": {
+                            "shebang-command": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "shebang-regex": "1.0.0"
+                              },
+                              "dependencies": {
+                                "shebang-regex": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "npm-run-path": {
+                          "version": "2.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "path-key": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-key": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "p-finally": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "signal-exit": {
+                          "version": "3.0.2",
+                          "bundled": true
+                        },
+                        "strip-eof": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "lcid": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "invert-kv": "1.0.0"
+                      },
+                      "dependencies": {
+                        "invert-kv": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "mem": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "mimic-fn": "1.2.0"
+                      },
+                      "dependencies": {
+                        "mimic-fn": {
+                          "version": "1.2.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "require-directory": {
+                  "version": "2.1.1",
+                  "bundled": true
+                },
+                "require-main-filename": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
+                  },
+                  "dependencies": {
+                    "is-fullwidth-code-point": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "which-module": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "y18n": {
+                  "version": "3.2.1",
+                  "bundled": true
+                },
+                "yargs-parser": {
+                  "version": "9.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "camelcase": "4.1.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "4.1.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "lockfile": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "lodash._baseindexof": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "lodash._baseuniq": {
+          "version": "4.6.0",
+          "bundled": true,
+          "requires": {
+            "lodash._createset": "4.0.3",
+            "lodash._root": "3.0.1"
+          },
+          "dependencies": {
+            "lodash._createset": {
+              "version": "4.0.3",
+              "bundled": true
+            },
+            "lodash._root": {
+              "version": "3.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "lodash._bindcallback": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "lodash._cacheindexof": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "lodash._createcache": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "lodash._getnative": "3.9.1"
+          }
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "bundled": true
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.restparam": {
+          "version": "3.6.1",
+          "bundled": true
+        },
+        "lodash.union": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "lodash.uniq": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.without": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          },
+          "dependencies": {
+            "pseudomap": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            }
+          }
+        },
+        "meant": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "mississippi": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.1",
+            "duplexify": "3.5.4",
+            "end-of-stream": "1.4.1",
+            "flush-write-stream": "1.0.2",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "3.0.0",
+            "pumpify": "1.4.0",
+            "stream-each": "1.2.2",
+            "through2": "2.0.3"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.6.1",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
+              },
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true
+                }
+              }
+            },
+            "duplexify": {
+              "version": "3.5.4",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "end-of-stream": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0"
+              }
+            },
+            "flush-write-stream": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
+              }
+            },
+            "from2": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
+              }
+            },
+            "parallel-transform": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
+              },
+              "dependencies": {
+                "cyclist": {
+                  "version": "0.2.2",
+                  "bundled": true
+                }
+              }
+            },
+            "pump": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+              }
+            },
+            "pumpify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "duplexify": "3.5.4",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
+              },
+              "dependencies": {
+                "pump": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "once": "1.4.0"
+                  }
+                }
+              }
+            },
+            "stream-each": {
+              "version": "1.2.2",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "through2": {
+              "version": "2.0.3",
+              "bundled": true,
+              "requires": {
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "xtend": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            }
+          }
+        },
+        "move-concurrently": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "copy-concurrently": "1.0.5",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
+          },
+          "dependencies": {
+            "copy-concurrently": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
+              },
+              "dependencies": {
+                "iferr": {
+                  "version": "0.1.5",
+                  "bundled": true
+                }
+              }
+            },
+            "run-queue": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.2.0"
+              }
+            }
+          }
+        },
+        "node-gyp": {
+          "version": "3.6.2",
+          "bundled": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.1.2",
+            "osenv": "0.1.5",
+            "request": "2.85.0",
+            "rimraf": "2.6.2",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.3.0"
+          },
+          "dependencies": {
+            "fstream": {
+              "version": "1.0.11",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.11"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.1.1"
+              }
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              },
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.9",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.6.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3"
+          },
+          "dependencies": {
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "builtin-modules": "1.1.1"
+              },
+              "dependencies": {
+                "builtin-modules": {
+                  "version": "1.1.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "npm-audit-report": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "ansicolors": "0.3.2",
+            "ansistyles": "0.1.3",
+            "cli-table2": "0.2.0"
+          }
+        },
+        "npm-cache-filename": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "npm-install-checks": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "semver": "5.5.0"
+          }
+        },
+        "npm-lifecycle": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "byline": "5.0.0",
+            "graceful-fs": "4.1.11",
+            "node-gyp": "3.6.2",
+            "resolve-from": "4.0.0",
+            "slide": "1.1.6",
+            "uid-number": "0.0.6",
+            "umask": "1.1.0",
+            "which": "1.3.0"
+          },
+          "dependencies": {
+            "byline": {
+              "version": "5.0.0",
+              "bundled": true
+            },
+            "resolve-from": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "npm-package-arg": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.6.0",
+            "osenv": "0.1.5",
+            "semver": "5.5.0",
+            "validate-npm-package-name": "3.0.0"
+          }
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          },
+          "dependencies": {
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "minimatch": "3.0.4"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.8"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.8",
+                      "bundled": true,
+                      "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "npm-pick-manifest": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
+          }
+        },
+        "npm-profile": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "make-fetch-happen": "2.6.0"
+          },
+          "dependencies": {
+            "make-fetch-happen": {
+              "version": "2.6.0",
+              "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.3.0",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.0.0",
+                "https-proxy-agent": "2.1.1",
+                "lru-cache": "4.1.2",
+                "mississippi": "1.3.1",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
+              },
+              "dependencies": {
+                "agentkeepalive": {
+                  "version": "3.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
+                  "dependencies": {
+                    "humanize-ms": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "cacache": {
+                  "version": "10.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.2",
+                    "mississippi": "2.0.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "5.3.0",
+                    "unique-filename": "1.1.0",
+                    "y18n": "4.0.0"
+                  },
+                  "dependencies": {
+                    "mississippi": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "2.0.1",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
+                      },
+                      "dependencies": {
+                        "concat-stream": {
+                          "version": "1.6.2",
+                          "bundled": true,
+                          "requires": {
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
+                          },
+                          "dependencies": {
+                            "buffer-from": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "typedarray": {
+                              "version": "0.0.6",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexify": {
+                          "version": "3.5.4",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0"
+                          }
+                        },
+                        "flush-write-stream": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "from2": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "parallel-transform": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          },
+                          "dependencies": {
+                            "cyclist": {
+                              "version": "0.2.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        },
+                        "pumpify": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
+                          }
+                        },
+                        "stream-each": {
+                          "version": "1.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
+                          },
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "y18n": {
+                      "version": "4.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "http-cache-semantics": {
+                  "version": "3.8.1",
+                  "bundled": true
+                },
+                "http-proxy-agent": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "2.6.9"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "2.6.9",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "https-proxy-agent": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "mississippi": {
+                  "version": "1.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "concat-stream": "1.6.0",
+                    "duplexify": "3.5.3",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.2",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "1.0.3",
+                    "pumpify": "1.4.0",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
+                  },
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.6.0",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "typedarray": "0.0.6"
+                      },
+                      "dependencies": {
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "duplexify": {
+                      "version": "3.5.3",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "end-of-stream": {
+                      "version": "1.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.4.0"
+                      }
+                    },
+                    "flush-write-stream": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      }
+                    },
+                    "from2": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      }
+                    },
+                    "parallel-transform": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "cyclist": "0.2.2",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      },
+                      "dependencies": {
+                        "cyclist": {
+                          "version": "0.2.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "pump": {
+                      "version": "1.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
+                      }
+                    },
+                    "pumpify": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "duplexify": "3.5.3",
+                        "inherits": "2.0.3",
+                        "pump": "2.0.1"
+                      },
+                      "dependencies": {
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        }
+                      }
+                    },
+                    "stream-each": {
+                      "version": "1.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "through2": {
+                      "version": "2.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "readable-stream": "2.3.6",
+                        "xtend": "4.0.1"
+                      },
+                      "dependencies": {
+                        "xtend": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-fetch-npm": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.1",
+                    "safe-buffer": "5.1.1"
+                  },
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.19"
+                      },
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.19",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "json-parse-better-errors": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "promise-retry": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
+                  },
+                  "dependencies": {
+                    "err-code": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    },
+                    "retry": {
+                      "version": "0.10.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "socks-proxy-agent": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks": {
+                      "version": "1.1.10",
+                      "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
+                      },
+                      "dependencies": {
+                        "ip": {
+                          "version": "1.1.5",
+                          "bundled": true
+                        },
+                        "smart-buffer": {
+                          "version": "1.1.15",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "ssri": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "npm-registry-client": {
+          "version": "8.5.1",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.1",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "request": "2.85.0",
+            "retry": "0.10.1",
+            "safe-buffer": "5.1.1",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "ssri": "5.3.0"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.6.1",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
+              },
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true
+                }
+              }
+            },
+            "retry": {
+              "version": "0.10.1",
+              "bundled": true
+            },
+            "ssri": {
+              "version": "5.3.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            }
+          }
+        },
+        "npm-registry-fetch": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "figgy-pudding": "2.0.1",
+            "lru-cache": "4.1.2",
+            "make-fetch-happen": "3.0.0",
+            "npm-package-arg": "6.1.0",
+            "safe-buffer": "5.1.1"
+          },
+          "dependencies": {
+            "figgy-pudding": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "make-fetch-happen": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.4.1",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.2",
+                "mississippi": "3.0.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
+              },
+              "dependencies": {
+                "agentkeepalive": {
+                  "version": "3.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
+                  "dependencies": {
+                    "humanize-ms": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "cacache": {
+                  "version": "10.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.2",
+                    "mississippi": "2.0.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "5.3.0",
+                    "unique-filename": "1.1.0",
+                    "y18n": "4.0.0"
+                  },
+                  "dependencies": {
+                    "mississippi": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "2.0.1",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
+                      },
+                      "dependencies": {
+                        "concat-stream": {
+                          "version": "1.6.2",
+                          "bundled": true,
+                          "requires": {
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
+                          },
+                          "dependencies": {
+                            "buffer-from": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "typedarray": {
+                              "version": "0.0.6",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexify": {
+                          "version": "3.5.4",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0"
+                          }
+                        },
+                        "flush-write-stream": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "from2": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "parallel-transform": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          },
+                          "dependencies": {
+                            "cyclist": {
+                              "version": "0.2.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        },
+                        "pumpify": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
+                          }
+                        },
+                        "stream-each": {
+                          "version": "1.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
+                          },
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "y18n": {
+                      "version": "4.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "http-cache-semantics": {
+                  "version": "3.8.1",
+                  "bundled": true
+                },
+                "http-proxy-agent": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "https-proxy-agent": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-fetch-npm": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.2",
+                    "safe-buffer": "5.1.1"
+                  },
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.21"
+                      },
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.21",
+                          "bundled": true,
+                          "requires": {
+                            "safer-buffer": "2.1.2"
+                          },
+                          "dependencies": {
+                            "safer-buffer": {
+                              "version": "2.1.2",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "promise-retry": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
+                  },
+                  "dependencies": {
+                    "err-code": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    },
+                    "retry": {
+                      "version": "0.10.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "socks-proxy-agent": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks": {
+                      "version": "1.1.10",
+                      "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
+                      },
+                      "dependencies": {
+                        "ip": {
+                          "version": "1.1.5",
+                          "bundled": true
+                        },
+                        "smart-buffer": {
+                          "version": "1.1.15",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "ssri": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "npm-user-validate": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          },
+          "dependencies": {
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.6"
+              },
+              "dependencies": {
+                "delegates": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+              },
+              "dependencies": {
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  },
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.1.0",
+                      "bundled": true
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "wide-align": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  }
+                }
+              }
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "opener": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          },
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "pacote": {
+          "version": "8.1.0",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "cacache": "11.0.1",
+            "get-stream": "3.0.0",
+            "glob": "7.1.2",
+            "lru-cache": "4.1.2",
+            "make-fetch-happen": "4.0.1",
+            "minimatch": "3.0.4",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npm-packlist": "1.1.10",
+            "npm-pick-manifest": "2.1.0",
+            "osenv": "0.1.5",
+            "promise-inflight": "1.0.1",
+            "promise-retry": "1.1.1",
+            "protoduck": "5.0.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.1",
+            "semver": "5.5.0",
+            "ssri": "6.0.0",
+            "tar": "4.4.1",
+            "unique-filename": "1.1.0",
+            "which": "1.3.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "make-fetch-happen": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.4.1",
+                "cacache": "11.0.1",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.2",
+                "mississippi": "3.0.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "4.0.1",
+                "ssri": "6.0.0"
+              },
+              "dependencies": {
+                "agentkeepalive": {
+                  "version": "3.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
+                  "dependencies": {
+                    "humanize-ms": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "http-cache-semantics": {
+                  "version": "3.8.1",
+                  "bundled": true
+                },
+                "http-proxy-agent": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "https-proxy-agent": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-fetch-npm": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.2",
+                    "safe-buffer": "5.1.1"
+                  },
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.21"
+                      },
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.21",
+                          "bundled": true,
+                          "requires": {
+                            "safer-buffer": "2.1.2"
+                          },
+                          "dependencies": {
+                            "safer-buffer": {
+                              "version": "2.1.2",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "socks-proxy-agent": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "socks": "2.2.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks": {
+                      "version": "2.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "4.0.1"
+                      },
+                      "dependencies": {
+                        "ip": {
+                          "version": "1.1.5",
+                          "bundled": true
+                        },
+                        "smart-buffer": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.11"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "promise-retry": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "err-code": "1.1.2",
+                "retry": "0.10.1"
+              },
+              "dependencies": {
+                "err-code": {
+                  "version": "1.1.2",
+                  "bundled": true
+                },
+                "retry": {
+                  "version": "0.10.1",
+                  "bundled": true
+                }
+              }
+            },
+            "protoduck": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "genfun": "4.0.1"
+              },
+              "dependencies": {
+                "genfun": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "promise-inflight": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "qrcode-terminal": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "decode-uri-component": "0.2.0",
+            "strict-uri-encode": "2.0.0"
+          },
+          "dependencies": {
+            "decode-uri-component": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "strict-uri-encode": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "qw": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "read": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "mute-stream": "0.0.7"
+          },
+          "dependencies": {
+            "mute-stream": {
+              "version": "0.0.7",
+              "bundled": true
+            }
+          }
+        },
+        "read-cmd-shim": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "read-installed": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "util-extend": "1.0.3"
+          },
+          "dependencies": {
+            "util-extend": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "read-package-json": {
+          "version": "2.0.13",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "json-parse-better-errors": "1.0.1",
+            "normalize-package-data": "2.4.0",
+            "slash": "1.0.0"
+          },
+          "dependencies": {
+            "json-parse-better-errors": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "slash": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "read-package-tree": {
+          "version": "5.2.1",
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "once": "1.4.0",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          },
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "readdir-scoped-modules": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "4.1.11",
+            "once": "1.4.0"
+          }
+        },
+        "request": {
+          "version": "2.85.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          },
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.7.0",
+              "bundled": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "form-data": {
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "2.1.18"
+              },
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0",
+                  "bundled": true
+                }
+              }
+            },
+            "har-validator": {
+              "version": "5.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
+              },
+              "dependencies": {
+                "ajv": {
+                  "version": "5.5.2",
+                  "bundled": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "fast-deep-equal": "1.1.0",
+                    "fast-json-stable-stringify": "2.0.0",
+                    "json-schema-traverse": "0.3.1"
+                  },
+                  "dependencies": {
+                    "co": {
+                      "version": "4.6.0",
+                      "bundled": true
+                    },
+                    "fast-deep-equal": {
+                      "version": "1.1.0",
+                      "bundled": true
+                    },
+                    "fast-json-stable-stringify": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    },
+                    "json-schema-traverse": {
+                      "version": "0.3.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "har-schema": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "hawk": {
+              "version": "6.0.2",
+              "bundled": true,
+              "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.1",
+                "sntp": "2.1.0"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "4.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "4.2.1"
+                  }
+                },
+                "cryptiles": {
+                  "version": "3.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "boom": "5.2.0"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "5.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "4.2.1"
+                      }
+                    }
+                  }
+                },
+                "hoek": {
+                  "version": "4.2.1",
+                  "bundled": true
+                },
+                "sntp": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "4.2.1"
+                  }
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.1"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "jsprim": {
+                  "version": "1.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "extsprintf": "1.3.0",
+                    "json-schema": "0.2.3",
+                    "verror": "1.10.0"
+                  },
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.3.0",
+                      "bundled": true
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "bundled": true
+                    },
+                    "verror": {
+                      "version": "1.10.0",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "extsprintf": "1.3.0"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.14.1",
+                  "bundled": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "bundled": true
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "0.14.5"
+                      }
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.1"
+                      }
+                    },
+                    "getpass": {
+                      "version": "0.1.7",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.18",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.33.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.33.0",
+                  "bundled": true
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true
+            },
+            "performance-now": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.1",
+              "bundled": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true
+            },
+            "tough-cookie": {
+              "version": "2.3.4",
+              "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              },
+              "dependencies": {
+                "punycode": {
+                  "version": "1.4.1",
+                  "bundled": true
+                }
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            }
+          }
+        },
+        "retry": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "sha": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "sorted-object": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "sorted-union-stream": {
+          "version": "2.1.3",
+          "bundled": true,
+          "requires": {
+            "from2": "1.3.0",
+            "stream-iterate": "1.2.0"
+          },
+          "dependencies": {
+            "from2": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.14",
+                  "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "stream-iterate": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "ssri": {
+          "version": "6.0.0",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          },
+          "dependencies": {
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "requires": {
+                "minipass": "2.2.4"
+              }
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "minipass": "2.2.4"
+              }
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "tiny-relative-date": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "umask": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "unique-filename": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "unique-slug": "2.0.0"
+          },
+          "dependencies": {
+            "unique-slug": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "imurmurhash": "0.1.4"
+              }
+            }
+          }
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "update-notifier": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "boxen": "1.3.0",
+            "chalk": "2.3.2",
+            "configstore": "3.1.2",
+            "import-lazy": "2.1.0",
+            "is-ci": "1.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
+          },
+          "dependencies": {
+            "boxen": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "ansi-align": "2.0.0",
+                "camelcase": "4.1.0",
+                "chalk": "2.3.2",
+                "cli-boxes": "1.0.0",
+                "string-width": "2.1.1",
+                "term-size": "1.2.0",
+                "widest-line": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-align": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "2.1.1"
+                  }
+                },
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "cli-boxes": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
+                  },
+                  "dependencies": {
+                    "is-fullwidth-code-point": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "term-size": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "execa": "0.7.0"
+                  },
+                  "dependencies": {
+                    "execa": {
+                      "version": "0.7.0",
+                      "bundled": true,
+                      "requires": {
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                      },
+                      "dependencies": {
+                        "cross-spawn": {
+                          "version": "5.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "lru-cache": "4.1.2",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
+                          },
+                          "dependencies": {
+                            "shebang-command": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "shebang-regex": "1.0.0"
+                              },
+                              "dependencies": {
+                                "shebang-regex": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "npm-run-path": {
+                          "version": "2.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "path-key": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-key": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "p-finally": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "signal-exit": {
+                          "version": "3.0.2",
+                          "bundled": true
+                        },
+                        "strip-eof": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "widest-line": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "2.1.1"
+                  }
+                }
+              }
+            },
+            "chalk": {
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.3.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.1"
+                  },
+                  "dependencies": {
+                    "color-convert": {
+                      "version": "1.9.1",
+                      "bundled": true,
+                      "requires": {
+                        "color-name": "1.1.3"
+                      },
+                      "dependencies": {
+                        "color-name": {
+                          "version": "1.1.3",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "bundled": true
+                },
+                "supports-color": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "3.0.0"
+                  },
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "configstore": {
+              "version": "3.1.2",
+              "bundled": true,
+              "requires": {
+                "dot-prop": "4.2.0",
+                "graceful-fs": "4.1.11",
+                "make-dir": "1.2.0",
+                "unique-string": "1.0.0",
+                "write-file-atomic": "2.3.0",
+                "xdg-basedir": "3.0.0"
+              },
+              "dependencies": {
+                "dot-prop": {
+                  "version": "4.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-obj": "1.0.1"
+                  },
+                  "dependencies": {
+                    "is-obj": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "make-dir": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "pify": "3.0.0"
+                  },
+                  "dependencies": {
+                    "pify": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "unique-string": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "crypto-random-string": "1.0.0"
+                  },
+                  "dependencies": {
+                    "crypto-random-string": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "import-lazy": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "is-ci": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "ci-info": "1.1.3"
+              },
+              "dependencies": {
+                "ci-info": {
+                  "version": "1.1.3",
+                  "bundled": true
+                }
+              }
+            },
+            "is-installed-globally": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "global-dirs": "0.1.1",
+                "is-path-inside": "1.0.1"
+              },
+              "dependencies": {
+                "global-dirs": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "ini": "1.3.5"
+                  }
+                },
+                "is-path-inside": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "path-is-inside": "1.0.2"
+                  }
+                }
+              }
+            },
+            "is-npm": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "latest-version": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "package-json": "4.0.1"
+              },
+              "dependencies": {
+                "package-json": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "got": "6.7.1",
+                    "registry-auth-token": "3.3.2",
+                    "registry-url": "3.1.0",
+                    "semver": "5.5.0"
+                  },
+                  "dependencies": {
+                    "got": {
+                      "version": "6.7.1",
+                      "bundled": true,
+                      "requires": {
+                        "create-error-class": "3.0.2",
+                        "duplexer3": "0.1.4",
+                        "get-stream": "3.0.0",
+                        "is-redirect": "1.0.0",
+                        "is-retry-allowed": "1.1.0",
+                        "is-stream": "1.1.0",
+                        "lowercase-keys": "1.0.1",
+                        "safe-buffer": "5.1.1",
+                        "timed-out": "4.0.1",
+                        "unzip-response": "2.0.1",
+                        "url-parse-lax": "1.0.0"
+                      },
+                      "dependencies": {
+                        "create-error-class": {
+                          "version": "3.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "capture-stack-trace": "1.0.0"
+                          },
+                          "dependencies": {
+                            "capture-stack-trace": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexer3": {
+                          "version": "0.1.4",
+                          "bundled": true
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        },
+                        "is-redirect": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "is-retry-allowed": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "lowercase-keys": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        },
+                        "timed-out": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        },
+                        "unzip-response": {
+                          "version": "2.0.1",
+                          "bundled": true
+                        },
+                        "url-parse-lax": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "prepend-http": "1.0.4"
+                          },
+                          "dependencies": {
+                            "prepend-http": {
+                              "version": "1.0.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry-auth-token": {
+                      "version": "3.3.2",
+                      "bundled": true,
+                      "requires": {
+                        "rc": "1.2.6",
+                        "safe-buffer": "5.1.1"
+                      },
+                      "dependencies": {
+                        "rc": {
+                          "version": "1.2.6",
+                          "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.4.2",
+                            "ini": "1.3.5",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
+                          "dependencies": {
+                            "deep-extend": {
+                              "version": "0.4.2",
+                              "bundled": true
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "bundled": true
+                            },
+                            "strip-json-comments": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry-url": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "rc": "1.2.6"
+                      },
+                      "dependencies": {
+                        "rc": {
+                          "version": "1.2.6",
+                          "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.4.2",
+                            "ini": "1.3.5",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
+                          "dependencies": {
+                            "deep-extend": {
+                              "version": "0.4.2",
+                              "bundled": true
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "bundled": true
+                            },
+                            "strip-json-comments": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "semver-diff": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "semver": "5.5.0"
+              }
+            },
+            "xdg-basedir": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
+          },
+          "dependencies": {
+            "spdx-correct": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
+              },
+              "dependencies": {
+                "spdx-license-ids": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
+              },
+              "dependencies": {
+                "spdx-exceptions": {
+                  "version": "2.1.0",
+                  "bundled": true
+                },
+                "spdx-license-ids": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "builtins": "1.0.3"
+          },
+          "dependencies": {
+            "builtins": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isexe": "2.0.0"
+          },
+          "dependencies": {
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "worker-farm": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "errno": "0.1.7"
+          },
+          "dependencies": {
+            "errno": {
+              "version": "0.1.7",
+              "bundled": true,
+              "requires": {
+                "prr": "1.0.1"
+              },
+              "dependencies": {
+                "prr": {
+                  "version": "1.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write-file-atomic": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
+          },
+          "dependencies": {
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        }
       }
     },
     "nth-check": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "commander": "",
     "js-yaml": "",
     "longjohn": "^0.2.11",
+    "npm": "^6.0.0",
     "optimist": "",
     "pretty-error": "^2.0.2",
     "rando-js": "^0.1.1",


### PR DESCRIPTION
Merged after testing for rebuild, but did not open client. Will do more research into what markedjs and npm 6 have to offer before attempting further tests and merging.